### PR TITLE
Pull Request

### DIFF
--- a/EventMessage/build.gradle
+++ b/EventMessage/build.gradle
@@ -20,10 +20,9 @@ repositories {
 }
 
 dependencies {
-	compile project(':Economy')
 	testCompile group: 'junit', name: 'junit', version: '4.12'
-	compile 'com.destroystokyo.paper:paper-api:1.14.1-R0.1-SNAPSHOT'
-	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+	implementation 'com.destroystokyo.paper:paper-api:1.14.1-R0.1-SNAPSHOT'
+	compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -37,12 +36,25 @@ processResources {
 buildscript {
 	ext.kotlin_version = '1.3.41'
 	repositories {
+		jcenter()
 		mavenCentral()
 	}
 	dependencies {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+		classpath "com.github.jengelman.gradle.plugins:shadow:5.1.0"
 	}
 }
+
+apply plugin: "kotlin"
+apply plugin: "com.github.johnrengelman.shadow"
+
+shadowJar {
+	configurations = [project.configurations.compile]
+}
+jar {
+	finalizedBy shadowJar
+}
+
 compileKotlin {
 	kotlinOptions {
 		jvmTarget = "1.8"

--- a/EventMessage/src/main/java/mbs/beta/event_message/EventMessage.kt
+++ b/EventMessage/src/main/java/mbs/beta/event_message/EventMessage.kt
@@ -2,47 +2,107 @@ package mbs.beta.event_message
 
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
-import org.bukkit.command.Command
-import org.bukkit.command.CommandSender
-import org.bukkit.event.EventHandler
+import org.bukkit.event.Event
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
-import org.bukkit.event.player.PlayerJoinEvent
-import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.player.PlayerEvent
+import org.bukkit.plugin.EventExecutor
 import org.bukkit.plugin.java.JavaPlugin
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.util.Arrays
+import java.util.Vector
 
 public class EventMessage : JavaPlugin(), Listener {
 
-
-    var join: String = "${ChatColor.YELLOW}<name>님이 들어왔습니다!";
-    var quit: String = "${ChatColor.YELLOW}<name>님이 나갔습니다!";
+    val placeholderAppliers: List<PlaceholderApplier> = Arrays.asList(
+            object:PlaceholderApplier(
+                    object:Placeholder() {
+                        override fun Replace(event: Event, string: String?): String? {
+                            val playerEvent = event as PlayerEvent
+                            return string?.replace("<name>", playerEvent.player.name)
+                        }
+                    }
+            ) {
+                override fun isAppliable(event: Event): Boolean {
+                    return event is PlayerEvent
+                }
+            }
+    )
+    val variables: HashMap<Class<out Event>, HashMap<Field, String?>> = HashMap()
+    val eventExecutor: EventExecutor = EventExecutor { _, event ->
+        val clazz: Class<out Event> = event.javaClass;
+        if (variables.containsKey(clazz)) {
+            val fields = variables.get(clazz)
+            for (entry in fields?.entries!!) {
+                var value = entry.value
+                val field = entry.key;
+                if (!value?.isEmpty()!!) {
+                    for (placeholderApplier in placeholderAppliers) {
+                        value = placeholderApplier.Apply(event, value)
+                    }
+                    field.isAccessible = true
+                    field.set(event, value)
+                }
+            }
+        }
+    }
+    var join: String = "${ChatColor.YELLOW}<name>님이 들어왔습니다!"
+    var quit: String = "${ChatColor.YELLOW}<name>님이 나갔습니다!"
 
     override fun onEnable() {
-        super.onEnable()
-        Bukkit.getPluginManager().registerEvents(this, this);
-        var b = false
-        if (config.contains("playerJoin"))
-            join = config.getString("playerJoin")!!
-        else {
-            config.set("playerJoin", join)
-            b = true
+        Bukkit.getPluginManager().registerEvents(this, this)
+
+        val classes: Field? = ClassLoader::class.java.getDeclaredField("classes");
+        classes?.isAccessible = true;
+
+        @Suppress("UNCHECKED_CAST") // Field 'classes' must be type 'Vector'
+        for (clazz in ArrayList(classes?.get(ClassLoader.getSystemClassLoader()) as Vector<Class<*>>)) {
+            if (Event::class.java.isAssignableFrom(clazz)) {
+                try {
+                    clazz.getDeclaredField("handlers")
+                    val fields: HashMap<Field, String?> = HashMap()
+                    val eventClass = clazz as Class<out Event>
+                    variables.put(eventClass, fields)
+                    for (field in clazz.declaredFields) {
+                        val modifiers: Int = field.modifiers
+                        if (!Modifier.isFinal(modifiers) && !Modifier.isStatic(modifiers) && String::class.java.isAssignableFrom(field.type)) {
+                            val path: String = clazz.name + "." + field.name;
+                            var value: String?
+                            if (config.contains(path)) {
+                                value = config.getString(path)
+                            } else {
+                                value = ""
+                                config.set(path, value)
+                            }
+                            fields.put(field, value)
+                        }
+                    }
+                    if (!fields.isEmpty()) {
+                        Bukkit.getPluginManager().registerEvent(eventClass, this, EventPriority.HIGH, eventExecutor, this)
+                    }
+                } catch(e: NoSuchFieldException) {}
+            }
         }
-        if (config.contains("playerQuit"))
-            quit = config.getString("playerQuit")!!
-        else {
-            config.set("playerQuit", quit)
-            b = true
-        }
-        if (b) saveConfig()
-
+        saveConfig()
     }
 
-    @EventHandler
-    public fun onJoinEvent(e: PlayerJoinEvent) {
-        e.joinMessage = join.replace("<name>", e.player.name)
-    }
-
-    @EventHandler
-    public fun onQuitEvent(e: PlayerQuitEvent) {
-        e.quitMessage = quit.replace("<name>", e.player.name)
-    }
 }
+
+abstract class PlaceholderApplier constructor(vararg val placeholders: Placeholder) {
+
+    abstract fun isAppliable(event: Event): Boolean
+
+    fun Apply(event: Event, string: String?): String? {
+        var result = string
+        if (isAppliable(event)) {
+            for (placeholder in placeholders) {
+                result = placeholder.Replace(event, result)
+            }
+        }
+        return result
+    }
+
+}
+
+abstract class Placeholder { abstract fun Replace(event: Event, string: String?): String? }

--- a/EventMessage/src/main/resources/plugin.yml
+++ b/EventMessage/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: EventMessage
 version: @version@
 main: mbs.beta.event_message.EventMessage
-authors: [M]
+authors: [M, Daybreak]


### PR DESCRIPTION
- PlayerJoinEvent, PlayerQuitEvent 외에도 수정할 수 있는 String field가
  존재하는 Event가 있을 경우 자동으로 확인하여 적용하도록 변경
- Gradle을 통해 build할 때 Kotlin을 shade하도록 변경
- super.onEnable()은 JavaPlugin에서 `public void onEnable() {}`와 같이 구현되어있기 때문에 호출할
  의미 없으므로 삭제
- Placeholder를 쉽게 관리할 수 있는 PlaceholderApplier와 Placeholder 클래스 추가


Bukkit이나 Spigot, Paper같은 환경에는 Kotlin이 기본적으로 없어서 Kotlin을 shade하도록 했더니
파일 크기가 약 146배 뻥튀기됐습니다. 이거 merge 하실거면 나중에 Kotlin만 다른 플러그인으로
빼서 지원해주는게 나을 것 같습니다.

**config.yml**
```
org:
  bukkit:
    event:
      server:
        ServerCommandEvent:
          command: ''
        BroadcastMessageEvent:
          message: ''
        ServerListPingEvent:
          motd: ''
      player:
        PlayerQuitEvent:
          quitMessage: ''
        PlayerLoginEvent:
          message: ''
        PlayerJoinEvent:
          joinMessage: ''
        AsyncPlayerChatEvent:
          message: ''
          format: ''
        PlayerCommandPreprocessEvent:
          message: ''
        AsyncPlayerPreLoginEvent:
          message: ''
        PlayerPreLoginEvent:
          message: ''
        PlayerKickEvent:
          leaveMessage: ''
          kickReason: ''
      command:
        UnknownCommandEvent:
          commandLine: ''
          message: ''

```

**테스트 플러그인:** [EventMessage-1.0-SNAPSHOT-all.zip](https://github.com/owjs3901/MBS_Beta/files/3774732/EventMessage-1.0-SNAPSHOT-all.zip)